### PR TITLE
Feature 7 file stripping

### DIFF
--- a/src/DoomerPublish/DoomerPublish.lib/Common/IFileContext.cs
+++ b/src/DoomerPublish/DoomerPublish.lib/Common/IFileContext.cs
@@ -9,6 +9,9 @@ public interface IFileContext
 	string AbsoluteFolderPath { get; }
 	string Content { get; }
 
+	// Specifies if this file should be stripped from the eventual output.
+	bool StripFromOutput { get; set; }
+
 	List<TodoItem>? Todos { get; set; }
 	IEnumerable<IFileContext>? IncludedFileContexts { get; }
 }

--- a/src/DoomerPublish/DoomerPublish.lib/Tools/AcsParseService/AcsContext.cs
+++ b/src/DoomerPublish/DoomerPublish.lib/Tools/AcsParseService/AcsContext.cs
@@ -69,6 +69,9 @@ public sealed class AcsFile : IFileContext
 	public List<TodoItem>? Todos { get; set; }
 	public string? Library { get; set; }
 
+	/// <inheritdoc />
+	public bool StripFromOutput { get; set; }
+
 	public IEnumerable<IFileContext>? IncludedFileContexts => this.IncludedFiles?.Cast<IFileContext>();
 
 	internal static async Task<AcsFile> FromPathAsync(string filePath, CancellationToken cancellationToken)

--- a/src/DoomerPublish/DoomerPublish.lib/Tools/DecorateParseService/DecorateContext.cs
+++ b/src/DoomerPublish/DoomerPublish.lib/Tools/DecorateParseService/DecorateContext.cs
@@ -26,6 +26,9 @@ public sealed class DecorateFile : IFileContext
 	public List<TodoItem>? Todos { get; set; }
 	public List<DecorateFile>? IncludedFiles { get; set; }
 
+	/// <inheritdoc />
+	public bool StripFromOutput { get; set; }
+
 	public IEnumerable<IFileContext>? IncludedFileContexts => this.IncludedFiles?.Cast<IFileContext>();
 
 	internal static async Task<DecorateFile> FromPathAsync(string filePath, CancellationToken cancellationToken)

--- a/src/DoomerPublish/DoomerPublishTool/Properties/launchSettings.json
+++ b/src/DoomerPublish/DoomerPublishTool/Properties/launchSettings.json
@@ -1,49 +1,54 @@
 {
-  "profiles": {
-    "Publish Help": {
-      "commandName": "Project",
-      "commandLineArgs": "--help"
-    },
+    "profiles": {
+        "Publish Help": {
+            "commandName": "Project",
+            "commandLineArgs": "--help"
+        },
 
-    // All the relative paths navigate into the template project that comes bundled with the main repository.
-    "Publish core Dev with ACC": {
-      "commandName": "Project",
-      "commandLineArgs": "\"..\\..\\..\\..\\..\\..\\template\\src\\TestProjectAcc\" --logOutput \"..\\..\\..\\..\\..\\..\\template\\logs\" --todoAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --decorateSummaryAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --compilerRoot \"..\\..\\..\\..\\..\\..\\template\\scripts\" --compileWith acc --defines \"dev\" --engine \"zandronum\" --publicAcs"
-    },
+        // All the relative paths navigate into the template project that comes bundled with the main repository.
+        "Publish core Dev with ACC": {
+            "commandName": "Project",
+            "commandLineArgs": "\"..\\..\\..\\..\\..\\..\\template\\src\\TestProjectAcc\" --logOutput \"..\\..\\..\\..\\..\\..\\template\\logs\" --todoAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --decorateSummaryAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --compilerRoot \"..\\..\\..\\..\\..\\..\\template\\scripts\" --compileWith acc --defines \"dev\" --engine \"zandronum\" --publicAcs"
+        },
 
-    "Publish core Dev with GDCC-ACC": {
-      "commandName": "Project",
-      "commandLineArgs": "\"..\\..\\..\\..\\..\\..\\template\\src\\TestProjectGdccAcc\" --logOutput \"..\\..\\..\\..\\..\\..\\template\\logs\" --todoAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --decorateSummaryAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --compilerRoot \"..\\..\\..\\..\\..\\..\\template\\scripts\" --compileWith gdccacc --noWarnForwardReferences --defines \"dev\" --engine \"zandronum\" --publicAcs"
-    },
+        "Publish core Dev with GDCC-ACC": {
+            "commandName": "Project",
+            "commandLineArgs": "\"..\\..\\..\\..\\..\\..\\template\\src\\TestProjectGdccAcc\" --logOutput \"..\\..\\..\\..\\..\\..\\template\\logs\" --todoAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --decorateSummaryAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --compilerRoot \"..\\..\\..\\..\\..\\..\\template\\scripts\" --compileWith gdccacc --noWarnForwardReferences --defines \"dev\" --engine \"zandronum\" --publicAcs"
+        },
 
-    "Publish core Dev with BCC": {
-      "commandName": "Project",
-      "commandLineArgs": "\"..\\..\\..\\..\\..\\..\\template\\src\\TestProjectBcc\" --logOutput \"..\\..\\..\\..\\..\\..\\template\\logs\" --todoAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --decorateSummaryAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --compilerRoot \"..\\..\\..\\..\\..\\..\\template\\scripts\" --compileWith bcc --defines \"dev\" --engine \"zandronum\" --publicAcs"
-    },
+        "Publish core Dev with BCC": {
+            "commandName": "Project",
+            "commandLineArgs": "\"..\\..\\..\\..\\..\\..\\template\\src\\TestProjectBcc\" --logOutput \"..\\..\\..\\..\\..\\..\\template\\logs\" --todoAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --decorateSummaryAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --compilerRoot \"..\\..\\..\\..\\..\\..\\template\\scripts\" --compileWith bcc --defines \"dev\" --engine \"zandronum\" --publicAcs"
+        },
 
-    "Publish maps through temp project with full stripping": {
-      "commandName": "Project",
-      "commandLineArgs": "\"..\\..\\..\\..\\..\\..\\template\\src\\TestProjectMaps\" --logOutput \"..\\..\\..\\..\\..\\..\\template\\logs\" --todoAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --decorateSummaryAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --packToOutput \"..\\..\\..\\..\\..\\..\\template\\build\" --tempProject --removeUnrelated --packDecorate --removeEmpty"
-    },
+        "Publish maps through temp project with full stripping": {
+            "commandName": "Project",
+            "commandLineArgs": "\"..\\..\\..\\..\\..\\..\\template\\src\\TestProjectMaps\" --logOutput \"..\\..\\..\\..\\..\\..\\template\\logs\" --todoAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --decorateSummaryAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --packToOutput \"..\\..\\..\\..\\..\\..\\template\\build\" --tempProject --removeUnrelated --packDecorate --removeEmpty"
+        },
 
-    "Publish resources through temp project with full stripping": {
-      "commandName": "Project",
-      "commandLineArgs": "\"..\\..\\..\\..\\..\\..\\template\\src\\TestProjectResources\" --logOutput \"..\\..\\..\\..\\..\\..\\template\\logs\" --todoAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --decorateSummaryAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --packToOutput \"..\\..\\..\\..\\..\\..\\template\\build\" --tempProject --removeUnrelated --packDecorate --removeEmpty"
-    },
+        "Publish resources dev through temp project with full stripping": {
+            "commandName": "Project",
+            "commandLineArgs": "\"..\\..\\..\\..\\..\\..\\template\\src\\TestProjectResources\" --logOutput \"..\\..\\..\\..\\..\\..\\template\\logs\" --todoAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --decorateSummaryAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --packToOutput \"..\\..\\..\\..\\..\\..\\template\\build\" --tempProject --removeUnrelated --packDecorate --removeEmpty"
+        },
 
-    "Publish core Prod through temp project with full stripping and compilation withACC": {
-      "commandName": "Project",
-      "commandLineArgs": "\"..\\..\\..\\..\\..\\..\\template\\src\\TestProjectAcc\" --logOutput \"..\\..\\..\\..\\..\\..\\template\\logs\" --todoAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --decorateSummaryAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --packToOutput \"..\\..\\..\\..\\..\\..\\template\\build\" --compilerRoot \"..\\..\\..\\..\\..\\..\\template\\scripts\" --compileWith gdccacc --engine \"zandronum\" --noWarnForwardReferences --publicAcs --tempProject --removeAcs --removeUnrelated --packDecorate --removeEmpty"
-    },
+        "Publish resources prod through temp project with full stripping": {
+            "commandName": "Project",
+            "commandLineArgs": "\"..\\..\\..\\..\\..\\..\\template\\src\\TestProjectResources\" --logOutput \"..\\..\\..\\..\\..\\..\\template\\logs\" --todoAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --decorateSummaryAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --packToOutput \"..\\..\\..\\..\\..\\..\\template\\build\" --stripFiles dev --tempProject --removeUnrelated --packDecorate --removeEmpty"
+        },
 
-    "Publish core Prod through temp project with full stripping and compilation with GDCC-ACC": {
-      "commandName": "Project",
-      "commandLineArgs": "\"..\\..\\..\\..\\..\\..\\template\\src\\TestProjectGdccAcc\" --logOutput \"..\\..\\..\\..\\..\\..\\template\\logs\" --todoAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --decorateSummaryAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --packToOutput \"..\\..\\..\\..\\..\\..\\template\\build\" --compilerRoot \"..\\..\\..\\..\\..\\..\\template\\scripts\" --compileWith acc --engine \"zandronum\" --noWarnForwardReferences --publicAcs --tempProject --removeAcs --removeUnrelated --packDecorate --removeEmpty"
-    },
+        "Publish core Prod through temp project with full stripping and compilation with ACC": {
+            "commandName": "Project",
+            "commandLineArgs": "\"..\\..\\..\\..\\..\\..\\template\\src\\TestProjectAcc\" --logOutput \"..\\..\\..\\..\\..\\..\\template\\logs\" --todoAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --decorateSummaryAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --packToOutput \"..\\..\\..\\..\\..\\..\\template\\build\" --compilerRoot \"..\\..\\..\\..\\..\\..\\template\\scripts\" --compileWith gdccacc --engine \"zandronum\" --noWarnForwardReferences --publicAcs --tempProject --removeAcs --removeUnrelated --packDecorate --removeEmpty"
+        },
 
-    "Publish core Prod through temp project with full stripping and compilation with BCC": {
-      "commandName": "Project",
-      "commandLineArgs": "\"..\\..\\..\\..\\..\\..\\template\\src\\TestProjectBcc\" --logOutput \"..\\..\\..\\..\\..\\..\\template\\logs\" --todoAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --decorateSummaryAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --packToOutput \"..\\..\\..\\..\\..\\..\\template\\build\" --compilerRoot \"..\\..\\..\\..\\..\\..\\template\\scripts\" --compileWith bcc --engine \"zandronum\" --noWarnForwardReferences --publicAcs --tempProject --removeAcs --removeUnrelated --packDecorate --removeEmpty"
+        "Publish core Prod through temp project with full stripping and compilation with GDCC-ACC": {
+            "commandName": "Project",
+            "commandLineArgs": "\"..\\..\\..\\..\\..\\..\\template\\src\\TestProjectGdccAcc\" --logOutput \"..\\..\\..\\..\\..\\..\\template\\logs\" --todoAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --decorateSummaryAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --packToOutput \"..\\..\\..\\..\\..\\..\\template\\build\" --compilerRoot \"..\\..\\..\\..\\..\\..\\template\\scripts\" --compileWith acc --engine \"zandronum\" --noWarnForwardReferences --publicAcs --tempProject --removeAcs --removeUnrelated --packDecorate --removeEmpty"
+        },
+
+        "Publish core Prod through temp project with full stripping and compilation with BCC": {
+            "commandName": "Project",
+            "commandLineArgs": "\"..\\..\\..\\..\\..\\..\\template\\src\\TestProjectBcc\" --logOutput \"..\\..\\..\\..\\..\\..\\template\\logs\" --todoAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --decorateSummaryAt \"..\\..\\..\\..\\..\\..\\template\\logs\" --packToOutput \"..\\..\\..\\..\\..\\..\\template\\build\" --compilerRoot \"..\\..\\..\\..\\..\\..\\template\\scripts\" --compileWith bcc --engine \"zandronum\" --noWarnForwardReferences --publicAcs --tempProject --removeAcs --removeUnrelated --packDecorate --removeEmpty"
+        }
     }
-  }
 }

--- a/src/DoomerPublish/DoomerPublishTool/Service/PublisherService/DefaultPublisherService.cs
+++ b/src/DoomerPublish/DoomerPublishTool/Service/PublisherService/DefaultPublisherService.cs
@@ -29,6 +29,7 @@ internal sealed class DefaultPublisherService : IPublisherService
 		typeof(GeneratePublicAcsSourceTask),
 		typeof(GenerateTodoListTask),
 		typeof(GenerateDecorateSummaryTask),
+		typeof(StripFilesTask),
 		typeof(CompileTask),
 		typeof(RemoveAcsSourceTask),
 		typeof(PackDecorateTask),

--- a/src/DoomerPublish/DoomerPublishTool/Service/PublisherService/PublishTasks/PackDecorateTask.cs
+++ b/src/DoomerPublish/DoomerPublishTool/Service/PublisherService/PublishTasks/PackDecorateTask.cs
@@ -83,6 +83,11 @@ internal sealed class PackDecorateTask : IPublishTask
 		var stringBuilder = new StringBuilder();
 		foreach (var decorateFile in decorateFiles)
 		{
+			// Do not process this decorate file if it's stripped from the output.
+			if (decorateFile.StripFromOutput) {
+				continue;
+			}
+
 			this.RecursiveProcessDecorateFile(decorateFile, stringBuilder);
 		}
 

--- a/src/DoomerPublish/DoomerPublishTool/Service/PublisherService/PublishTasks/StripFilesTask.cs
+++ b/src/DoomerPublish/DoomerPublishTool/Service/PublisherService/PublishTasks/StripFilesTask.cs
@@ -1,0 +1,40 @@
+﻿using DoomerPublish.Tools.Acs;
+using Microsoft.Extensions.Logging;
+
+namespace DoomerPublish.PublishTasks;
+
+/// <summary>
+/// This task strips any files that end with the given strings from the project. This includes included files included in the parent file.
+/// </summary>
+internal sealed class StripFilesTask : IPublishTask
+{
+	/// <inheritdoc cref="ILogger" />
+	private readonly ILogger _logger;
+
+	public StripFilesTask(
+		ILogger<StripFilesTask> logger)
+	{
+		this._logger = logger;
+	}
+
+	public Task RunAsync(PublishContext context, CancellationToken stoppingToken)
+	{
+		if (stoppingToken.IsCancellationRequested)
+		{
+			return Task.CompletedTask;
+		}
+
+		// User does not want to strip any files.
+		if (context.Configuration.Stripfiles == null || !context.Configuration.Stripfiles.Any())
+		{
+			return Task.CompletedTask;
+		}
+
+#pragma warning disable IDE0059
+		var projectContext = context.ProjectContext ??
+			throw new InvalidOperationException("Expected a project context.");
+#pragma warning restore IDE0059
+
+		throw new NotImplementedException();
+	}
+}

--- a/src/DoomerPublish/DoomerPublishTool/Service/PublisherService/PublisherConfiguration.cs
+++ b/src/DoomerPublish/DoomerPublishTool/Service/PublisherService/PublisherConfiguration.cs
@@ -77,6 +77,9 @@ public class PublisherConfiguration
 	[Option(longName: "removeAcs", Required = false, HelpText = "Specify to remove the acs source.")]
 	public bool RemoveAcsSource { get; init; }
 
+	[Option(longName: "stripFiles", Required = false, HelpText = "Specify to strip base files ending in the given string or strings from the project. This will also strip included files.")]
+	public IEnumerable<string>? Stripfiles { get; init; }
+
 	[Option(longName: "removeUnrelated", Required = false, HelpText = "Specify to remove unrelated files.")]
 	public bool RemoveUnrelatedFiles { get; init; }
 


### PR DESCRIPTION
This change adds the ability to strip files that contain the given suffix, and also checks this for folders. For example, specifying `dev` will remove `decorate.dev` if it exists, and also remove the `dev` folder inside your sprites folder. Useful for stripping developmental assets for example.